### PR TITLE
#io.js is now #node-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,9 @@ it may be related to #Node.js the channel doesn't discuss it often or in great
 detail. You may get more love in `#libuv` or `#v8`.
 
 ####The #Node.js channel has a few cousins:
-<a name="io.js"></a>
-##### #io.js
-This channel is where discussions surrounding the community maintained & governed
-Node.js fork - io.js - often happen. Most of the collaborators engage in here, and
-it is a great place for discussing both broad topics about node, and node's internals.
+<a name="#node-dev"></a>
+##### #node-dev
+#node-dev is the channel for discussing Node.js core development and other things related to the Node.js Project itself. Most of the collaborators engage in here, and it is a great place for discussing both broad topics about node, and node's internals.
 
 <a name="#javascript"></a>
 ##### ##javascript


### PR DESCRIPTION
# io.js is now invite only, and forwards to #node-dev (+if). Update here accordingly. :D
